### PR TITLE
Make jmap_client::Error implement std::error::Error using thiserror

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,6 +373,8 @@ pub enum Error {
     WebSocket(tokio_tungstenite::tungstenite::error::Error),
 }
 
+impl std::error::Error for Error {}
+
 impl From<reqwest::Error> for Error {
     fn from(e: reqwest::Error) -> Self {
         Error::Transport(e)


### PR DESCRIPTION
I use anyhow in parts of my application, and noticed that the core error type doesn't implement std::error::Error. I have used thiserror which is a compile-time-only macro for doing this automatically. Incidentally, it also allows us to clean up some boilerplate.

This also means that errors from this library can be used downstream using the same #[from] machinery :)

I decided to move the display impl block further up now that the error display impl block was gone, but I can drop that change.