### PR TITLE
chore(docs): add released RFC for JMAP-Sieve

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ _jmap-client_ is a **JSON Meta Application Protocol (JMAP) library** written in 
 - JMAP Core ([RFC 8620](https://datatracker.ietf.org/doc/html/rfc8620))
 - JMAP for Mail ([RFC 8621](https://datatracker.ietf.org/doc/html/rfc8621)) 
 - JMAP over WebSocket ([RFC 8887](https://datatracker.ietf.org/doc/html/rfc8887)).
-- JMAP for Sieve Scripts ([DRAFT-SIEVE-14](https://www.ietf.org/archive/id/draft-ietf-jmap-sieve-14.html)).
+- JMAP for Sieve Scripts ([RFC 9661](https://datatracker.ietf.org/doc/html/rfc9661)).
 
 Features:
 


### PR DESCRIPTION
JMAP for Sieve Scripts is released on 27.09.2024:
https://datatracker.ietf.org/doc/rfc9661/

Is this library feature complete with the changes of the Draft?

See here the changes on RFC:
https://author-tools.ietf.org/iddiff?url1=draft-ietf-jmap-sieve-14&url2=rfc9661&difftype=--html