### PR TITLE
fix: join multi-line SSE data fields with newline (fixes #19)

### DIFF
--- a/src/event_source/parser.rs
+++ b/src/event_source/parser.rs
@@ -194,6 +194,9 @@ impl Iterator for EventParser {
                                 self.result.id.extend_from_slice(&self.value);
                             }
                             b"data" => {
+                                if !self.result.data.is_empty() {
+                                    self.result.data.push(b'\n');
+                                }
                                 self.result.data.extend_from_slice(&self.value);
                             }
                             b"event" => match &self.value[..] {
@@ -307,7 +310,7 @@ mod tests {
                 EventString {
                     event: EventType::State,
                     id: "".to_string(),
-                    data: "YHOO+210".to_string()
+                    data: "YHOO\n+2\n10".to_string()
                 },
                 EventString {
                     event: EventType::State,


### PR DESCRIPTION
Adds a newline separator before appending to the data buffer when it is non-empty, per the WHATWG SSE spec.

- **Commit 1** adds a failing test that demonstrates the bug
- **Commit 2** applies the fix (3 lines changed)

Fixes #19