### PR TITLE
fix: reset parser position when new SSE bytes are pushed (fixes #21)

### DIFF
--- a/src/event_source/parser.rs
+++ b/src/event_source/parser.rs
@@ -64,6 +64,7 @@ pub struct EventParser {
 impl EventParser {
     pub fn push_bytes(&mut self, bytes: Vec<u8>) {
         self.bytes = Some(bytes);
+        self.pos = 0;
     }
 
     pub fn needs_bytes(&self) -> bool {


### PR DESCRIPTION
Adds `self.pos = 0` in `push_bytes()` so that a new buffer is always read from the beginning.

- **Commit 1** adds a failing test that demonstrates the data loss
- **Commit 2** applies the one-line fix

Fixes #21