### PR TITLE
fix: stop stripping leading spaces from SSE field names (fixes #25)

### DIFF
--- a/src/event_source/parser.rs
+++ b/src/event_source/parser.rs
@@ -151,7 +151,7 @@ impl Iterator for EventParser {
                     b':' => {
                         self.state = EventParserState::Comment;
                     }
-                    b'\r' | b' ' => (),
+                    b'\r' => (),
                     b'\n' => {
                         return Some(Ok(std::mem::take(&mut self.result)));
                     }


### PR DESCRIPTION
Removes `b' '` from the Init-state match arm so that a space at the start of a line is treated as part of the field name, not silently discarded. This aligns with the WHATWG SSE spec which defines the field name as everything before the first colon, with no whitespace stripping.

- **Commit 1** adds a failing test that demonstrates the bug
- **Commit 2** applies the one-character fix

Fixes #25