### PR TITLE
fix: correct method in set_vacation_response RequestParams (fixes #27)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -465,8 +465,62 @@ impl From<(String, String)> for Credentials {
 }
 
 #[cfg(test)]
+impl Client {
+    pub(crate) fn test_client() -> Self {
+        let session: Session = serde_json::from_value(serde_json::json!({
+            "capabilities": {},
+            "accounts": {},
+            "primaryAccounts": {},
+            "username": "test@example.com",
+            "apiUrl": "https://example.com/jmap",
+            "downloadUrl": "https://example.com/download/{blobId}",
+            "uploadUrl": "https://example.com/upload",
+            "eventSourceUrl": "https://example.com/events",
+            "state": "0"
+        }))
+        .unwrap();
+        Client {
+            download_url: URLPart::parse(session.download_url()).unwrap(),
+            upload_url: URLPart::parse(session.upload_url()).unwrap(),
+            #[cfg(feature = "async")]
+            event_source_url: URLPart::parse(session.event_source_url()).unwrap(),
+            api_url: session.api_url().to_string(),
+            session: parking_lot::Mutex::new(Arc::new(session)),
+            session_url: "https://example.com/.well-known/jmap".to_string(),
+            session_updated: true.into(),
+            accept_invalid_certs: false,
+            trusted_hosts: Arc::new(AHashSet::new()),
+            #[cfg(feature = "websockets")]
+            authorization: String::new(),
+            timeout: Duration::from_secs(10),
+            headers: header::HeaderMap::new(),
+            default_account_id: "test-account".to_string(),
+            #[cfg(feature = "websockets")]
+            ws: tokio::sync::Mutex::new(None),
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use crate::core::response::{Response, TaggedMethodResponse};
+
+    /// VacationResponse/set must store Method::SetVacationResponse in its
+    /// RequestParams so that result references built from the call carry the
+    /// correct method name per RFC 8620 Section 3.7.
+    #[test]
+    fn set_vacation_response_result_reference_method() {
+        let client = super::Client::test_client();
+        let mut request = client.build();
+        let set_req = request.set_vacation_response();
+        let result_ref = set_req.result_reference("/created");
+        let json = serde_json::to_value(&result_ref).unwrap();
+        assert_eq!(
+            json["name"], "VacationResponse/set",
+            "result reference from VacationResponse/set should have name \
+             'VacationResponse/set', not 'VacationResponse/get'"
+        );
+    }
 
     #[test]
     fn test_deserialize() {

--- a/src/core/set.rs
+++ b/src/core/set.rs
@@ -9,7 +9,7 @@
  * except according to those terms.
  */
 
-use crate::Error;
+use crate::{Error, Method};
 use ahash::AHashMap;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -26,6 +26,9 @@ pub trait SetObject: Object {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct SetRequest<O: SetObject> {
+    #[serde(skip)]
+    method: (Method, usize),
+
     #[serde(rename = "accountId")]
     #[serde(skip_serializing_if = "Option::is_none")]
     account_id: Option<String>,
@@ -150,6 +153,7 @@ pub enum SetErrorType {
 impl<O: SetObject> SetRequest<O> {
     pub fn new(params: RequestParams) -> Self {
         Self {
+            method: (params.method, params.call_id),
             account_id: if O::requires_account_id() {
                 params.account_id.into()
             } else {
@@ -240,6 +244,10 @@ impl<O: SetObject> SetRequest<O> {
 
     pub fn arguments(&mut self) -> &mut O::SetArguments {
         &mut self.arguments
+    }
+
+    pub fn result_reference(&self, path: impl Into<String>) -> ResultReference {
+        ResultReference::new(self.method.0, self.method.1, path)
     }
 }
 

--- a/src/vacation_response/helpers.rs
+++ b/src/vacation_response/helpers.rs
@@ -149,7 +149,7 @@ impl Request<'_> {
         self.add_capability(URI::VacationResponse);
         self.add_method_call(
             Method::SetVacationResponse,
-            Arguments::vacation_response_set(self.params(Method::GetVacationResponse)),
+            Arguments::vacation_response_set(self.params(Method::SetVacationResponse)),
         )
         .vacation_response_set_mut()
     }


### PR DESCRIPTION
Fixes a copy-paste error where `set_vacation_response()` passed `Method::GetVacationResponse` to `self.params()` instead of `Method::SetVacationResponse`.

Also adds `method` storage and `result_reference()` to `SetRequest`, matching the pattern already used by `GetRequest`, `ChangesRequest`, and `QueryRequest`. This both exposes the bug and completes the result reference support for `/set` method calls.

- **Commit 1** adds `result_reference()` to `SetRequest` and a test that reveals the wrong method name
- **Commit 2** fixes the one-character typo in `vacation_response/helpers.rs`

Fixes #27